### PR TITLE
Implement separate script that reloads all dependencies, independently from yarndevtools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ __pycache__
 tests/logs
 tests/cdsw/logs/
 /tests/common/logs/
+/build/
+/junit/
+/.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ Note: The individual CDSW jobs should make sure for themselves to clone the repo
 
 5. All you have to do in CDSW is to set up the projects and their starter scripts like this:
 
-| Project                         | Starter script location|
-|---------------------------------|------------------------|  
-| Jira umbrella checker reporting | jobs/jira-umbrella-checker/cdsw_runner.py|
-| Unit test result aggregator     | jobs/unit-test-result-aggregator/cdsw_runner.py|
-| Unit test result reporting      | jobs/unit-test-result-reporting/cdsw_runner.py|
-| Downstream branchdiff reporting | jobs/downstream-branchdiff-reporting/cdsw_runner.py|
-| Review sheet backport updater   | jobs/review-sheet-backport-updater/cdsw_runner.py|
-| Reviewsync                      | jobs/reviewsync/cdsw_runner.py|
+| Project                         | Starter script location          | Parameter to script             |
+|---------------------------------|----------------------------------|---------------------------------|
+| Jira umbrella checker reporting | downloaded_scripts/start_job.py  | jira-umbrella-checker           |
+| Unit test result aggregator     | downloaded_scripts/start_job.py  | unit-test-result-aggregator     |
+| Unit test result reporting      | downloaded_scripts/start_job.py  | unit-test-result-reporting      |
+| Downstream branchdiff reporting | downloaded_scripts/start_job.py  | downstream-branchdiff-reporting |
+| Review sheet backport updater   | downloaded_scripts/start_job.py  | review-sheet-backport-updater   |
+| Reviewsync                      | downloaded_scripts/start_job.py  | reviewsync                      |

--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ Note: The individual CDSW jobs should make sure for themselves to clone the repo
 
 5. All you have to do in CDSW is to set up the projects and their starter scripts like this:
 
-| Project                         | Starter script location          | Parameter to script             |
-|---------------------------------|----------------------------------|---------------------------------|
-| Jira umbrella checker reporting | downloaded_scripts/start_job.py  | jira-umbrella-checker           |
-| Unit test result aggregator     | downloaded_scripts/start_job.py  | unit-test-result-aggregator     |
-| Unit test result reporting      | downloaded_scripts/start_job.py  | unit-test-result-reporting      |
-| Downstream branchdiff reporting | downloaded_scripts/start_job.py  | downstream-branchdiff-reporting |
-| Review sheet backport updater   | downloaded_scripts/start_job.py  | review-sheet-backport-updater   |
-| Reviewsync                      | downloaded_scripts/start_job.py  | reviewsync                      |
+| Project                         | Starter script location         | Arguments for script            |
+|---------------------------------|---------------------------------|---------------------------------|
+| Jira umbrella checker reporting | scripts/start_job.py            | jira-umbrella-checker           |
+| Unit test result aggregator     | scripts/start_job.py            | unit-test-result-aggregator     |
+| Unit test result reporting      | scripts/start_job.py            | unit-test-result-reporting      |
+| Downstream branchdiff reporting | scripts/start_job.py            | downstream-branchdiff-reporting |
+| Review sheet backport updater   | scripts/start_job.py | review-sheet-backport-updater   |
+| Reviewsync                      | scripts/start_job.py | reviewsync                      |

--- a/yarndevtools/argparser.py
+++ b/yarndevtools/argparser.py
@@ -56,6 +56,7 @@ class ArgParser:
         ArgParser.add_jenkins_test_reporter(subparsers, yarn_dev_tools)
         ArgParser.add_review_sheet_backport_updater(subparsers, yarn_dev_tools)
         ArgParser.add_reviewsync(subparsers, yarn_dev_tools)
+        ArgParser.add_test_result_aggregator(subparsers, yarn_dev_tools)
 
         # Normal arguments
         parser.add_argument(

--- a/yarndevtools/cdsw/common_python/cdsw_common.py
+++ b/yarndevtools/cdsw/common_python/cdsw_common.py
@@ -110,18 +110,6 @@ class CdswSetupResult:
 
 class CdswSetup:
     @staticmethod
-    def fix_pythonpath(additional_dir):
-        pypath = CdswEnvVar.PYTHONPATH.value
-        if pypath in os.environ:
-            LOG.debug(f"Old {pypath}: {CdswSetup._get_pythonpath()}")
-            OsUtils.set_env_value(pypath, f"{CdswSetup._get_pythonpath()}:{additional_dir}")
-            LOG.debug(f"New {pypath}: {CdswSetup._get_pythonpath()}")
-        else:
-            LOG.debug(f"Old {pypath}: not set")
-            OsUtils.set_env_value(pypath, additional_dir)
-            LOG.debug(f"New {pypath}: {CdswSetup._get_pythonpath}")
-
-    @staticmethod
     def _get_pythonpath():
         return OsUtils.get_env_value(CdswEnvVar.PYTHONPATH.value)
 

--- a/yarndevtools/cdsw/common_python/cdsw_common.py
+++ b/yarndevtools/cdsw/common_python/cdsw_common.py
@@ -50,6 +50,7 @@ from pythoncommons.process import SubprocessCommandRunner
 
 # Constants
 # TODO Move this to EnvVar enum
+from yarndevtools.cdsw.common_python.restarter import Restarter
 from yarndevtools.common.shared_command_utils import SECRET_PROJECTS_DIR, CommandType
 from yarndevtools.constants import YARNDEVTOOLS_MODULE_NAME
 
@@ -272,51 +273,7 @@ class CdswRunnerBase(ABC):
         if setup_result.install_requirements_invoked and OsUtils.is_env_var_true(
             CdswEnvVar.RESTART_PROCESS_WHEN_REQUIREMENTS_INSTALLED.value, default_val=False
         ):
-            self.restart_execution()
-
-    def restart_execution(self):
-        """
-         Variable values in case of CDSW run:
-         1. sys.executable: /usr/local/bin/python3
-         2. sys.argv: ['/usr/local/bin/ipython3']
-         3. final command: ['/usr/local/bin/python3',
-                   '/home/cdsw/.local/lib/python3.8/site-packages/yarndevtools/cdsw/unit-test-result-reporting/cdsw_runner.py']
-
-         Variable values under normal run (e.g. from test_branchdiff_reporter.py):
-         1. sys.executable: /usr/local/bin/python3
-         2. sys.argv: ['/home/cdsw/jobs/downstream-branchdiff-reporting/cdsw_runner.py']
-         3. final command: ['/usr/local/bin/python3', '/usr/local/lib/python3.8/site-packages/yarndevtools/cdsw/downstream-branchdiff-reporting/cdsw_runner.py']
-        :return:
-        """
-
-        # Let's pick two random environment variables that are starting with name "CDSW_" to decide if we are running on CDSW
-        real_cdsw_env = OsUtils.get_env_value("CDSW_PROJECT", None) and OsUtils.get_env_value("CDSW_ENGINE_URL", None)
-        if real_cdsw_env:
-            LOG.info("Detected real CDSW environment")
-            if not sys.argv:
-                raise ValueError("Was expecting sys.argv to be not empty! Current value: {}".format(sys.argv))
-            elif len(sys.argv) > 1:
-                raise ValueError("Was expecting sys.argv to have a length of 1! Current value: {}".format(sys.argv))
-            argv0 = sys.argv[0]
-            if "ipython" not in argv0:
-                raise ValueError("Was expecting sys.argv[] to contain 'ipython'! Current value: {}".format(argv0))
-            executable = sys.executable
-            command_args = [argv0, self.cdsw_runner_script_path]
-        else:
-            LOG.info("Detected artificial CDSW environment")
-            executable = sys.executable
-            command_args = [self.cdsw_runner_script_path]
-
-        LOG.info(
-            "Restarting Python process. " "sys.executable: %s, sys.argv: %s, executable: %s, command args: %s",
-            sys.executable,
-            sys.argv,
-            executable,
-            command_args,
-        )
-        # Prevent running the restart process forever
-        OsUtils.set_env_value(CdswEnvVar.RESTART_PROCESS_WHEN_REQUIREMENTS_INSTALLED.value, False)
-        os.execvp(executable, command_args)
+            Restarter.restart_execution(self.cdsw_runner_script_path)
 
     @abstractmethod
     def start(self, basedir, cdsw_runner_script_path: str):

--- a/yarndevtools/cdsw/common_python/constants.py
+++ b/yarndevtools/cdsw/common_python/constants.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+# TODO Move these to enums?
 BRANCH_DIFF_REPORTER_DIR_NAME = "downstream-branchdiff-reporting"
 JIRA_UMBRELLA_CHECKER_DIR_NAME = "jira-umbrella-checker"
 UNIT_TEST_RESULT_AGGREGATOR_DIR_NAME = "unit-test-result-aggregator"

--- a/yarndevtools/cdsw/common_python/constants.py
+++ b/yarndevtools/cdsw/common_python/constants.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-# TODO Move these to enums?
+# TODO Move these to enum: CommandType
 BRANCH_DIFF_REPORTER_DIR_NAME = "downstream-branchdiff-reporting"
 JIRA_UMBRELLA_CHECKER_DIR_NAME = "jira-umbrella-checker"
 UNIT_TEST_RESULT_AGGREGATOR_DIR_NAME = "unit-test-result-aggregator"
@@ -13,6 +13,7 @@ CDSW_RUNNER_PY = "cdsw_runner.py"
 
 
 # TODO Add default value of all env vars to enum
+# TODO Move all EnvVar classes to commands?
 class CdswEnvVar(Enum):
     MAIL_ACC_PASSWORD = "MAIL_ACC_PASSWORD"
     MAIL_ACC_USER = "MAIL_ACC_USER"

--- a/yarndevtools/cdsw/common_python/restarter.py
+++ b/yarndevtools/cdsw/common_python/restarter.py
@@ -1,0 +1,56 @@
+import logging
+import os
+import sys
+
+from pythoncommons.os_utils import OsUtils
+
+from yarndevtools.cdsw.common_python.constants import CdswEnvVar
+
+LOG = logging.getLogger(__name__)
+
+
+class Restarter:
+    @staticmethod
+    def restart_execution(cdsw_runner_script_path):
+        """
+         Variable values in case of CDSW run:
+         1. sys.executable: /usr/local/bin/python3
+         2. sys.argv: ['/usr/local/bin/ipython3']
+         3. final command: ['/usr/local/bin/python3',
+                   '/home/cdsw/.local/lib/python3.8/site-packages/yarndevtools/cdsw/unit-test-result-reporting/cdsw_runner.py']
+
+         Variable values under normal run (e.g. from test_branchdiff_reporter.py):
+         1. sys.executable: /usr/local/bin/python3
+         2. sys.argv: ['/home/cdsw/jobs/downstream-branchdiff-reporting/cdsw_runner.py']
+         3. final command: ['/usr/local/bin/python3', '/usr/local/lib/python3.8/site-packages/yarndevtools/cdsw/downstream-branchdiff-reporting/cdsw_runner.py']
+        :return:
+        """
+
+        # Let's pick two random environment variables that are starting with name "CDSW_" to decide if we are running on CDSW
+        real_cdsw_env = OsUtils.get_env_value("CDSW_PROJECT", None) and OsUtils.get_env_value("CDSW_ENGINE_URL", None)
+        if real_cdsw_env:
+            LOG.info("Detected real CDSW environment")
+            if not sys.argv:
+                raise ValueError("Was expecting sys.argv to be not empty! Current value: {}".format(sys.argv))
+            elif len(sys.argv) > 1:
+                raise ValueError("Was expecting sys.argv to have a length of 1! Current value: {}".format(sys.argv))
+            argv0 = sys.argv[0]
+            if "ipython" not in argv0:
+                raise ValueError("Was expecting sys.argv[] to contain 'ipython'! Current value: {}".format(argv0))
+            executable = sys.executable
+            command_args = [argv0, cdsw_runner_script_path]
+        else:
+            LOG.info("Detected artificial CDSW environment")
+            executable = sys.executable
+            command_args = [cdsw_runner_script_path]
+
+        LOG.info(
+            "Restarting Python process. " "sys.executable: %s, sys.argv: %s, executable: %s, command args: %s",
+            sys.executable,
+            sys.argv,
+            executable,
+            command_args,
+        )
+        # Prevent running the restart process forever
+        OsUtils.set_env_value(CdswEnvVar.RESTART_PROCESS_WHEN_REQUIREMENTS_INSTALLED.value, False)
+        os.execvp(executable, command_args)

--- a/yarndevtools/cdsw/libreloader/reload_dependencies.py
+++ b/yarndevtools/cdsw/libreloader/reload_dependencies.py
@@ -8,9 +8,9 @@ import sys
 from typing import List
 
 LOG = logging.getLogger(__name__)
-CDSW_BASEDIR = os.path.join("home", "cdsw")
+CDSW_BASEDIR = os.path.join("/home", "cdsw")
 YARN_DEV_TOOLS_JOBS_BASEDIR = os.path.join(CDSW_BASEDIR, "jobs")  # Same as CommonDirs.YARN_DEV_TOOLS_JOBS_BASEDIR
-INSTALL_REQUIREMENTS_SCRIPT = os.path.join(CDSW_BASEDIR, "downloaded_scripts", "install-requirements.sh")
+INSTALL_REQUIREMENTS_SCRIPT = os.path.join(CDSW_BASEDIR, "scripts", "install-requirements.sh")
 
 MODULE_MODE_GLOBAL = "global"
 MODULE_MODE_USER = "user"
@@ -34,7 +34,7 @@ CDSW_SCRIPT_DIR_NAMES = [
     JIRA_UMBRELLA_CHECKER_DIR_NAME,
     UNIT_TEST_RESULT_AGGREGATOR_DIR_NAME,
     REVIEW_SHEET_BACKPORT_UPDATER_DIR_NAME,
-    REVIEWSYNC_DIR_NAME,
+    # REVIEWSYNC_DIR_NAME, # TODO Add back later
     UNIT_TEST_RESULT_REPORTING_DIR_NAME,
 ]
 
@@ -46,6 +46,7 @@ class Reloader:
 
     @classmethod
     def start(cls):
+        logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
         cls._check_mandatory_scripts()
         python_site = cls._setup_python_module_root()
         cls.YARN_DEV_TOOLS_MODULE_ROOT = os.path.join(python_site, YARNDEVTOOLS_MODULE_NAME)

--- a/yarndevtools/cdsw/libreloader/reload_dependencies.py
+++ b/yarndevtools/cdsw/libreloader/reload_dependencies.py
@@ -1,0 +1,165 @@
+#!/usr/bin/python3
+import logging
+import os
+import shutil
+import site
+import subprocess
+import sys
+from typing import List
+
+LOG = logging.getLogger(__name__)
+CDSW_BASEDIR = os.path.join("home", "cdsw")
+YARN_DEV_TOOLS_JOBS_BASEDIR = os.path.join(CDSW_BASEDIR, "jobs")  # Same as CommonDirs.YARN_DEV_TOOLS_JOBS_BASEDIR
+INSTALL_REQUIREMENTS_SCRIPT = os.path.join(CDSW_BASEDIR, "downloaded_scripts", "install-requirements.sh")
+
+MODULE_MODE_GLOBAL = "global"
+MODULE_MODE_USER = "user"
+ACCEPTED_PYTHON_MODULE_MODES = [MODULE_MODE_USER, MODULE_MODE_GLOBAL]  # Same as values of PythonModuleMode
+PYTHON_MODULE_MODE_ENV_VAR = "PYTHON_MODULE_MODE"  # Same as CdswEnvVar.PYTHON_MODULE_MODE
+INSTALL_REQUIREMENTS_ENV_VAR = "INSTALL_REQUIREMENTS"  # Same as CdswEnvVar.INSTALL_REQUIREMENTS
+TEST_EXECUTION_MODE_ENV_VAR = "TEST_EXEC_MODE"  # Same as CdswEnvVar.TEST_EXECUTION_MODE
+YARNDEVTOOLS_MODULE_NAME = "yarndevtools"
+DEFAULT_TEST_EXECUTION_MODE = "cloudera"  # Same as TestExecMode.CLOUDERA.value
+
+
+BRANCH_DIFF_REPORTER_DIR_NAME = "downstream-branchdiff-reporting"
+JIRA_UMBRELLA_CHECKER_DIR_NAME = "jira-umbrella-checker"
+UNIT_TEST_RESULT_AGGREGATOR_DIR_NAME = "unit-test-result-aggregator"
+REVIEW_SHEET_BACKPORT_UPDATER_DIR_NAME = "review-sheet-backport-updater"
+REVIEWSYNC_DIR_NAME = "reviewsync"
+UNIT_TEST_RESULT_REPORTING_DIR_NAME = "unit-test-result-reporting"
+# Same as CommonDirs.CDSW_SCRIPT_DIR_NAMES
+CDSW_SCRIPT_DIR_NAMES = [
+    BRANCH_DIFF_REPORTER_DIR_NAME,
+    JIRA_UMBRELLA_CHECKER_DIR_NAME,
+    UNIT_TEST_RESULT_AGGREGATOR_DIR_NAME,
+    REVIEW_SHEET_BACKPORT_UPDATER_DIR_NAME,
+    REVIEWSYNC_DIR_NAME,
+    UNIT_TEST_RESULT_REPORTING_DIR_NAME,
+]
+
+CDSW_RUNNER_PY = "cdsw_runner.py"
+
+
+class Reloader:
+    YARN_DEV_TOOLS_MODULE_ROOT = None
+
+    @classmethod
+    def start(cls):
+        cls._check_mandatory_scripts()
+        python_site = cls._setup_python_module_root()
+        cls.YARN_DEV_TOOLS_MODULE_ROOT = os.path.join(python_site, YARNDEVTOOLS_MODULE_NAME)
+        LOG.info("YARN dev tools module root is: %s", cls.YARN_DEV_TOOLS_MODULE_ROOT)
+
+        cls._install_requirements_if_needed()
+        LOG.info("{} Finished execution succesfully".format(sys.argv[0]))
+
+    @classmethod
+    def _check_mandatory_scripts(cls):
+        if not os.path.isfile(INSTALL_REQUIREMENTS_SCRIPT):
+            raise ValueError(
+                "Cannot find file {}. Make sure you ran the initial-cdsw-setup.sh script once!".format(
+                    INSTALL_REQUIREMENTS_SCRIPT
+                )
+            )
+
+    @classmethod
+    def _install_requirements_if_needed(cls):
+        install_requirements = True
+        if INSTALL_REQUIREMENTS_ENV_VAR in os.environ:
+            env_var_value = os.environ[INSTALL_REQUIREMENTS_ENV_VAR]
+            if env_var_value == "True" or env_var_value is True:
+                install_requirements = True
+            else:
+                install_requirements = False
+        if install_requirements:
+            cls._run_install_requirements_script()
+        else:
+            LOG.warning("Skipping installation of Python requirements as per configuration!")
+
+    @classmethod
+    def _setup_python_module_root(cls):
+        # For CDSW execution, user python module mode is preferred.
+        # For test execution, it depends on how the initial-cdsw-setup.sh script was executed in the container.
+        python_module_mode = MODULE_MODE_USER
+        if PYTHON_MODULE_MODE_ENV_VAR in os.environ:
+            python_module_mode = os.environ[PYTHON_MODULE_MODE_ENV_VAR]
+            LOG.info("Found python module mode from env var '%': %s", PYTHON_MODULE_MODE_ENV_VAR, python_module_mode)
+
+        if python_module_mode not in ACCEPTED_PYTHON_MODULE_MODES:
+            raise ValueError(
+                "Accepted python module modes: {}. Provided module mode: {}".format(
+                    ACCEPTED_PYTHON_MODULE_MODES, python_module_mode
+                )
+            )
+
+        LOG.info("Using Python module mode: %s", python_module_mode)
+        if python_module_mode == MODULE_MODE_GLOBAL:
+            python_site = site.getsitepackages()[0]
+            LOG.info("Using global python-site basedir: %s", python_site)
+        elif python_module_mode == MODULE_MODE_USER:
+            python_site = site.USER_SITE
+            LOG.info("Using user python-site basedir: %s", python_site)
+        else:
+            raise ValueError("Invalid python module mode: {}".format(python_module_mode))
+
+        return python_site
+
+    @classmethod
+    def _run_install_requirements_script(cls, exit_on_nonzero_exitcode=False):
+        """
+        Do not exit on non-zero exit code as pip can fail to remove residual package files on NFS.
+        See: https://github.com/pypa/pip/issues/6327
+        :param exit_on_nonzero_exitcode:
+        :return:
+        """
+        script = INSTALL_REQUIREMENTS_SCRIPT
+        exec_mode = DEFAULT_TEST_EXECUTION_MODE
+        if TEST_EXECUTION_MODE_ENV_VAR in os.environ:
+            exec_mode = os.environ[TEST_EXECUTION_MODE_ENV_VAR]
+        cls._run_script(script, args=[exec_mode], exit_on_nonzero_exitcode=exit_on_nonzero_exitcode)
+        cls._copy_cdsw_jobs_to_yarndevtools_cdsw_runner_scripts()
+
+    @classmethod
+    def _copy_cdsw_jobs_to_yarndevtools_cdsw_runner_scripts(cls):
+        # IMPORTANT: CDSW is able to launch linked scripts, but cannot modify and save the job's form because it thinks
+        # the linked script is not there.
+        LOG.info("Copying jobs to place...")
+        for job_dirname in CDSW_SCRIPT_DIR_NAMES:
+            cdsw_runner_of_job = os.path.join(cls.YARN_DEV_TOOLS_MODULE_ROOT, "cdsw", job_dirname, CDSW_RUNNER_PY)
+            if not os.path.isfile(cdsw_runner_of_job):
+                raise ValueError("Cannot find script: {}".format(cdsw_runner_of_job))
+
+            # It's safer to delete dirs one by one explicitly, without specifying just the parent
+            cdsw_job_dir = os.path.join(YARN_DEV_TOOLS_JOBS_BASEDIR, job_dirname)
+            cls.remove_dir(cdsw_job_dir, force=True)
+
+            cls.create_new_dir(cdsw_job_dir)
+            target_script_path = os.path.join(cdsw_job_dir, CDSW_RUNNER_PY)
+            cls.copy_file(cdsw_runner_of_job, target_script_path)
+
+    @classmethod
+    def remove_dir(cls, dir, force=False):
+        if force:
+            shutil.rmtree(dir, ignore_errors=True)
+        else:
+            os.rmdir(dir)
+
+    @classmethod
+    def create_new_dir(cls, path):
+        if not os.path.exists(path):
+            os.makedirs(path)
+        else:
+            raise ValueError("Directory already exist: %s", path)
+
+    @classmethod
+    def copy_file(cls, src, dest):
+        LOG.info(f"Copying file. {src} -> {dest}")
+        shutil.copyfile(src, dest)
+
+    @classmethod
+    def _run_script(cls, script, args: List[str], exit_on_nonzero_exitcode=True):
+        proc = subprocess.Popen(["/bin/bash", "-x", script, *args], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+        _ = proc.communicate()
+        if proc.returncode != 0 and exit_on_nonzero_exitcode:
+            raise ValueError(f"Failed to execute {script}")

--- a/yarndevtools/cdsw/scripts/initial-cdsw-setup.sh
+++ b/yarndevtools/cdsw/scripts/initial-cdsw-setup.sh
@@ -41,6 +41,7 @@ echo "Downloading clone repository scripts..."
 SCRIPTS_DIR="/home/cdsw/downloaded_scripts"
 mkdir $SCRIPTS_DIR
 
+
 #No errors allowed after this point!
 set -e
 
@@ -52,6 +53,11 @@ chmod +x $SCRIPTS_DIR/clone_downstream_repos.sh
 chmod +x $SCRIPTS_DIR/clone_upstream_repos.sh
 chmod +x $SCRIPTS_DIR/install-requirements.sh
 chmod +x $SCRIPTS_DIR/start_job.py
+
+mkdir $SCRIPTS_DIR/libreloader
+touch $SCRIPTS_DIR/libreloader/__init__.py
+curl -o $SCRIPTS_DIR/libreloader/reload_dependencies.py https://raw.githubusercontent.com/szilard-nemeth/yarn-dev-tools/master/yarndevtools/cdsw/libreloader/reload_dependencies.py
+chmod +x $SCRIPTS_DIR/libreloader/reload_dependencies.py
 
 # Always run clone_upstream_repos.sh
 echo "Cloning upstream repos..."

--- a/yarndevtools/cdsw/scripts/initial-cdsw-setup.sh
+++ b/yarndevtools/cdsw/scripts/initial-cdsw-setup.sh
@@ -38,7 +38,7 @@ echo "Python module mode: $PYTHON_MODULE_MODE"
 echo "Execution mode: $EXEC_MODE"
 
 echo "Downloading clone repository scripts..."
-SCRIPTS_DIR="/home/cdsw/downloaded_scripts"
+SCRIPTS_DIR="/home/cdsw/scripts"
 mkdir $SCRIPTS_DIR
 
 

--- a/yarndevtools/cdsw/start_job.py
+++ b/yarndevtools/cdsw/start_job.py
@@ -4,11 +4,36 @@ import sys
 
 import libreloader.reload_dependencies  # DO NOT REMOVE !!
 
+PYTHONPATH_ENV_VAR = "PYTHONPATH"
+
+
+def get_pythonpath():
+    return os.environ[PYTHONPATH_ENV_VAR]
+
+
+def set_env_value(env, value):
+    os.environ[env] = value
+
+
+def fix_pythonpath(additional_dir):
+    pypath = PYTHONPATH_ENV_VAR
+    if pypath in os.environ:
+        print(f"Old {pypath}: {get_pythonpath()}")
+        set_env_value(pypath, f"{get_pythonpath()}:{additional_dir}")
+        print(f"New {pypath}: {get_pythonpath()}")
+    else:
+        print(f"Old {pypath}: not set")
+        set_env_value(pypath, additional_dir)
+        print(f"New {pypath}: {get_pythonpath()}")
+
+
 print(f"Name of the script      : {sys.argv[0]=}")
 print(f"Arguments of the script : {sys.argv[1:]=}")
 if len(sys.argv) != 2:
     raise ValueError("Should only have one argument, the name of the job!")
 
+downloaded_scripts_dir = os.path.join(os.path.expanduser("~"), "cdsw", "downloaded_scripts")
+fix_pythonpath(downloaded_scripts_dir)
 job_name = sys.argv[1]
 script_path = os.path.join(os.path.expanduser("~"), "cdsw", "jobs", job_name, "cdsw_runner.py")
 exec(open(script_path).read())

--- a/yarndevtools/cdsw/start_job.py
+++ b/yarndevtools/cdsw/start_job.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+import os
+import sys
+
+import libreloader.reload_dependencies  # DO NOT REMOVE !!
+
+print(f"Name of the script      : {sys.argv[0]=}")
+print(f"Arguments of the script : {sys.argv[1:]=}")
+if len(sys.argv) != 2:
+    raise ValueError("Should only have one argument, the name of the job!")
+
+job_name = sys.argv[1]
+script_path = os.path.join(os.path.expanduser("~"), "cdsw", "jobs", job_name, "cdsw_runner.py")
+exec(open(script_path).read())

--- a/yarndevtools/cdsw/start_job.py
+++ b/yarndevtools/cdsw/start_job.py
@@ -2,8 +2,7 @@
 import os
 import sys
 
-import libreloader.reload_dependencies  # DO NOT REMOVE !!
-
+# THESE FUNCTION DEFINITIONS AND CALL TO fix_pythonpast MUST PRECEDE THE IMPORT OF libreloader: from libreloader import reload_dependencies
 PYTHONPATH_ENV_VAR = "PYTHONPATH"
 
 
@@ -25,15 +24,24 @@ def fix_pythonpath(additional_dir):
         print(f"Old {pypath}: not set")
         set_env_value(pypath, additional_dir)
         print(f"New {pypath}: {get_pythonpath()}")
+    sys.path.append(additional_dir)
+    print("Fixed sys.path: " + str(sys.path))
+    print("Fixed PYTHONPATH: " + str(os.environ["PYTHONPATH"]))
 
+
+scripts_dir = os.path.join("/home", "cdsw", "scripts")
+fix_pythonpath(scripts_dir)
+
+# NOW IT'S SAFE TO IMPORT LIBRELOADER
+# IGNORE FLAKE8: E402 module level import not at top of file
+from libreloader import reload_dependencies  # DO NOT REMOVE !! # noqa: E402
 
 print(f"Name of the script      : {sys.argv[0]=}")
 print(f"Arguments of the script : {sys.argv[1:]=}")
 if len(sys.argv) != 2:
     raise ValueError("Should only have one argument, the name of the job!")
 
-downloaded_scripts_dir = os.path.join(os.path.expanduser("~"), "cdsw", "downloaded_scripts")
-fix_pythonpath(downloaded_scripts_dir)
+reload_dependencies.Reloader.start()
 job_name = sys.argv[1]
-script_path = os.path.join(os.path.expanduser("~"), "cdsw", "jobs", job_name, "cdsw_runner.py")
+script_path = os.path.join("/home", "cdsw", "jobs", job_name, "cdsw_runner.py")
 exec(open(script_path).read())

--- a/yarndevtools/yarn_dev_tools.py
+++ b/yarndevtools/yarn_dev_tools.py
@@ -66,6 +66,7 @@ class YarnDevTools:
         self.init_repos()
 
     def setup_dirs(self, execution_mode: ExecutionMode = ExecutionMode.PRODUCTION):
+        strategy = None
         if execution_mode == ExecutionMode.PRODUCTION:
             strategy = ProjectRootDeterminationStrategy.SYS_PATH
         elif execution_mode == ExecutionMode.TEST:
@@ -74,7 +75,7 @@ class YarnDevTools:
             env_value = OsUtils.get_env_value(YarnDevToolsEnvVar.PROJECT_DETERMINATION_STRATEGY.value)
             LOG.info("Found specified project root determination strategy from env var: %s", env_value)
             strategy = ProjectRootDeterminationStrategy[env_value.upper()]
-        else:
+        if not strategy:
             raise ValueError("Unknown project root determination strategy!")
         LOG.info("Project root determination strategy is: %s", strategy)
         ProjectUtils.project_root_determine_strategy = strategy


### PR DESCRIPTION
This is to avoid issues with Python dependencies on NFS mounts, for example: 
```
+ pip3 uninstall -y yarn-dev-tools
Found existing installation: yarn-dev-tools 1.0.0.dev0
Uninstalling yarn-dev-tools-1.0.0.dev0:
Successfully uninstalled yarn-dev-tools-1.0.0.dev0
ERROR: Exception:
Traceback (most recent call last):
File "/usr/local/lib/python3.8/site-packages/pip/_internal/cli/base_command.py", line 189, in _main
status = self.run(options, args)
File "/usr/local/lib/python3.8/site-packages/pip/_internal/commands/uninstall.py", line 91, in run
uninstall_pathset.commit()
File "/usr/local/lib/python3.8/site-packages/pip/_internal/req/req_uninstall.py", line 456, in commit
self._moved_paths.commit()
File "/usr/local/lib/python3.8/site-packages/pip/_internal/req/req_uninstall.py", line 296, in commit
save_dir.cleanup()
File "/usr/local/lib/python3.8/site-packages/pip/_internal/utils/temp_dir.py", line 207, in cleanup
rmtree(self._path)
File "/usr/local/lib/python3.8/site-packages/pip/_vendor/retrying.py", line 49, in wrapped_f
return Retrying(*dargs, **dkw).call(f, *args, **kw)
File "/usr/local/lib/python3.8/site-packages/pip/_vendor/retrying.py", line 212, in call
raise attempt.get()
File "/usr/local/lib/python3.8/site-packages/pip/_vendor/retrying.py", line 247, in get
six.reraise(self.value[0], self.value[1], self.value[2])
File "/usr/local/lib/python3.8/site-packages/pip/_vendor/six.py", line 703, in reraise
raise value
File "/usr/local/lib/python3.8/site-packages/pip/_vendor/retrying.py", line 200, in call
attempt = Attempt(fn(*args, **kwargs), attempt_number, False)
File "/usr/local/lib/python3.8/site-packages/pip/_internal/utils/misc.py", line 129, in rmtree
shutil.rmtree(dir, ignore_errors=ignore_errors,
File "/usr/local/lib/python3.8/shutil.py", line 715, in rmtree
_rmtree_safe_fd(fd, path, onerror)
File "/usr/local/lib/python3.8/shutil.py", line 652, in _rmtree_safe_fd
_rmtree_safe_fd(dirfd, fullname, onerror)
File "/usr/local/lib/python3.8/shutil.py", line 652, in _rmtree_safe_fd
_rmtree_safe_fd(dirfd, fullname, onerror)
File "/usr/local/lib/python3.8/shutil.py", line 672, in _rmtree_safe_fd
onerror(os.unlink, fullname, sys.exc_info())
File "/usr/local/lib/python3.8/shutil.py", line 670, in _rmtree_safe_fd
os.unlink(entry.name, dir_fd=topfd)
OSError: [Errno 16] Device or resource busy: '.nfs000000000c242c230017e6af'
+ pip3 uninstall -y python-commons
Found existing installation: python-commons 0.1.0
Uninstalling python-commons-0.1.0:
Successfully uninstalled python-commons-0.1.0
+ pip3 uninstall -y google-api-wrapper
Found existing installation: google-api-wrapper 0.1.0
Uninstalling google-api-wrapper-0.1.0:
Successfully uninstalled google-api-wrapper-0.1.0
```
